### PR TITLE
Add inport for fullcalendar-theme.html

### DIFF
--- a/fullcalendar-calendar.html
+++ b/fullcalendar-calendar.html
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
+<link rel="import" href="fullcalendar-theme.html">
 
 <!--
 Web Component wrapper for FullCalendar.


### PR DESCRIPTION
Without this line it complains that theme `fullcalendar-theme` can not be found.

<img width="640" alt="screen shot 2016-07-15 at 3 45 31 pm" src="https://cloud.githubusercontent.com/assets/460336/16886607/40db94c4-4aa3-11e6-8d5a-da6b0c0b1028.png">
